### PR TITLE
Improve client-only compatibility

### DIFF
--- a/src/main/java/mezz/nopotionshift/NoPotionShift.java
+++ b/src/main/java/mezz/nopotionshift/NoPotionShift.java
@@ -1,13 +1,24 @@
 package mezz.nopotionshift;
 
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ExtensionPoint;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
+import org.apache.commons.lang3.tuple.Pair;
 
 @Mod("nopotionshift")
 public class NoPotionShift {
 	public NoPotionShift() {
+		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientEvent);
+		ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
+	}
+
+	public void registerClientEvent() {
 		MinecraftForge.EVENT_BUS.addListener(
 				EventPriority.NORMAL,
 				false,


### PR DESCRIPTION
These changes attempt to address two small issues relating to the mod's loading process, mainly with Forge being confused about the mod not being present on the server. If the mod is not present on the server, Forge will assume the server to be incompatible. At the same time, if the mod is installed on the server, the event will attempt to run which causes a crash. This mod should not be loaded server side of course, but in the event it is, this will ensure it is not being called on the server.