### PR TITLE
Port to 1.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: "net.minecraftforge.gradle", name: "ForgeGradle", version: "3.+", changing: true
+        classpath group: "net.minecraftforge.gradle", name: "ForgeGradle", version: "5.1.+", changing: true
     }
 }
 apply plugin: "net.minecraftforge.gradle"
@@ -24,7 +24,7 @@ dependencies {
 }
 
 minecraft {
-    mappings channel: "snapshot", version: project.mcp_mappings
+    mappings channel: "official", version: project.mcversion
 
     runs {
         client {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,10 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-mcversion=1.16.4
-forgeversion=35.1.37
+mcversion=1.17.1
+forgeversion=37.0.52
 forgegroup=net.minecraftforge
-mcp_mappings=20200723-1.16.1
 
 version_major=1
-version_minor=6
-version_patch=1
+version_minor=7
+version_patch=0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Jul 03 16:30:45 PDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Jul 03 16:30:45 PDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/mezz/nopotionshift/NoPotionShift.java
+++ b/src/main/java/mezz/nopotionshift/NoPotionShift.java
@@ -5,20 +5,20 @@ import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.fml.ExtensionPoint;
+import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.network.FMLNetworkConstants;
-import org.apache.commons.lang3.tuple.Pair;
 
 @Mod("nopotionshift")
 public class NoPotionShift {
 	public NoPotionShift() {
-		DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> this::registerClientEvent);
-		ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
+		DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> PotionShiftHandler::registerClientEvent);
+		ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> "ANY", (remote, side) -> side));
 	}
+}
 
-	public void registerClientEvent() {
+class PotionShiftHandler {
+	public static void registerClientEvent() {
 		MinecraftForge.EVENT_BUS.addListener(
 				EventPriority.NORMAL,
 				false,

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[33,)"
+loaderVersion="[37,)"
 license="MIT"
 issueTrackerURL="https://github.com/mezz/NoPotionShift/issues"
 [[mods]]
@@ -12,6 +12,6 @@ description='''Stops potion effects from moving guis to the right.'''
 [[dependencies.nopotionshift]]
     modId="forge"
     mandatory=true
-    versionRange="[33,)"
+    versionRange="[37,)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Ports to 1.17, version bumped to 1.7.0, FG5, Gradle 7, and a Forge requirement of 37+ (If this was done in error, I do apologize for assumedly editing otherwise, and am happy to re-edit)

The potion shift event has been nested into its own class to allow for a safe parallel run on the `DistExecutor`.